### PR TITLE
added FILES section

### DIFF
--- a/git-mailz.1
+++ b/git-mailz.1
@@ -83,6 +83,13 @@ may be influenced by environment variables used by
 .Xr zsh 1 ,
 possibly others.
 .\" ENVIRONMENT }}}
+.\" FILES {{{
+.Sh FILES
+.Nm
+uses
+.Xr git-config 1
+to retrieve configuration settings.
+.\" FILES }}}
 .\" EXAMPLES {{{
 .\"Sh EXAMPLES
 .\" EXAMPLES }}}


### PR DESCRIPTION
before the fix the [configuration] section's location was ambiguous. Now a FILES section is present, consistent with git-pimp's man pages.
